### PR TITLE
fix: remove unused files in root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,5 @@
   },
   "engines": {
     "yarn": ">=1"
-  },
-  "files": [
-    "/dist",
-    "LICENSE"
-  ]
+  }
 }


### PR DESCRIPTION
Those entries were added when we referenced to dist  files using git dependency, they should have been removed in 984c871.