### PR TITLE
fix: don't tab through all tablist items

### DIFF
--- a/packages/emoji-mart/src/components/Navigation/Navigation.tsx
+++ b/packages/emoji-mart/src/components/Navigation/Navigation.tsx
@@ -78,6 +78,7 @@ export default class Navigation extends PureComponent {
                 type="button"
                 class="flex flex-grow flex-center"
                 role="tab"
+                tabIndex={selected ? 0 : -1}
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => {
                   this.props.onClick({ category, i })


### PR DESCRIPTION
Tab should only focus the active item in the tablist, second Tab should
move the focus to the next element in the document.

"When focus moves into the tab list, places focus on the active tab element.
When the tab list contains the focus, moves focus to the next element in
the page tab sequence outside the tablist, which is the tabpanel unless
the first element containing meaningful content inside the tabpanel is focusable."

https://www.w3.org/WAI/ARIA/apg/patterns/tabs/

Relates to PS-20252.
