### PR TITLE
chore: take over the ownership of emoji-mart-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Data required for the picker to work has been completely decoupled from the libr
 - **Cons:** Slower initial page load (bigger file to load)
 
 ```sh
-yarn add @emoji-mart/data
+yarn add @slidoapp/emoji-mart-data
 ```
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import { Picker } from '@slidoapp/emoji-mart'
 
 new Picker({ data })
@@ -46,7 +46,7 @@ import { Picker } from '@slidoapp/emoji-mart'
 new Picker({
   data: async () => {
     const response = await fetch(
-      'https://cdn.jsdelivr.net/npm/@emoji-mart/data',
+      'https://cdn.jsdelivr.net/npm/@slidoapp/emoji-mart-data',
     )
 
     return response.json()
@@ -59,11 +59,11 @@ In this example data is fetched from a content delivery network, but it could al
 ## 🏪 Picker
 ### React
 ```sh
-npm install --save @slidoapp/emoji-mart @emoji-mart/data @slidoapp/emoji-mart-react
+npm install --save @slidoapp/emoji-mart @slidoapp/emoji-mart-data @slidoapp/emoji-mart-react
 ```
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import Picker from '@slidoapp/emoji-mart-react'
 
 function App() {
@@ -101,7 +101,7 @@ function App() {
 | **emojiButtonRadius** | `100%` | i.e. `6px`, `1em`, `100%` | The radius of the emoji buttons |
 | **emojiButtonSize** | `36` | | The size of the emoji buttons |
 | **emojiSize** | `24` | | The size of the emojis (inside the buttons) |
-| **emojiVersion** | `14` | `1`, `2`, `3`, `4`, `5`, `11`, `12`, `12.1`, `13`, `13.1`, `14` | The version of the emoji data to use. Latest version supported in `@emoji-mart/data` is currently [14](https://emojipedia.org/emoji-14.0) |
+| **emojiVersion** | `14` | `1`, `2`, `3`, `4`, `5`, `11`, `12`, `12.1`, `13`, `13.1`, `14` | The version of the emoji data to use. Latest version supported in `@slidoapp/emoji-mart-data` is currently [14](https://emojipedia.org/emoji-14.0) |
 | **exceptEmojis** | `[]` | | List of emoji IDs that will be excluded from the picker |
 | **icons** | `auto` | `auto`, `outline`, `solid` | The type of icons to use for the picker. `outline` with light theme and `solid` with dark theme. |
 | **locale** | `en` | `en`, `ar`, `be`, `cs`, `de`, `es`, `fa`, `fi`, `fr`, `hi`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `ru`, `sa`, `tr`, `uk`, `vi`, `zh` | The locale to use for the picker |
@@ -123,7 +123,7 @@ function App() {
 You can use custom emojis by providing an array of categories and their emojis. Emojis also support multiple skin tones and can be GIFs or SVGs.
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import Picker from '@slidoapp/emoji-mart-react'
 
 const custom = [
@@ -191,7 +191,7 @@ The emoji web component usage is the same no matter what library you use.
 First, you need to make sure data has been initialized. You need to call this only once per page load. Note that if you call `init` like this, you don’t necessarily need to include data in your Picker props. It doesn’t hurt either, it will noop.
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import { init } from '@slidoapp/emoji-mart'
 
 init({ data })
@@ -221,7 +221,7 @@ Then you can use the emoji component in your HTML / JSX.
 You can search without the Picker. Just like the emoji component, `data` needs to be initialized first in order to use the search index.
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import { init, SearchIndex } from '@slidoapp/emoji-mart'
 
 init({ data })
@@ -242,7 +242,7 @@ search('christmas') // => ['🎄', '🇨🇽', '🧑‍🎄', '🔔', '🤶', '�
 You can get emoji data from a native emoji. This is useful if you want to get the emoji ID from a native emoji. Just like the emoji component, `data` needs to be initialized first in order to retrieve the emoji data.
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import { init, getEmojiDataFromNative } from '@slidoapp/emoji-mart'
 
 init({ data })
@@ -264,7 +264,7 @@ getEmojiDataFromNative('🤞🏿').then(console.log)
 EmojiMart UI supports [multiple languages](https://github.com/slidoapp/emoji-mart/tree/main/packages/emoji-mart-data/i18n), feel free to open a PR if yours is missing.
 
 ```js
-import i18n from '@emoji-mart/data/i18n/fr.json'
+import i18n from '@slidoapp/emoji-mart-data/i18n/fr.json'
 i18n.search_no_results_1 = 'Aucun emoji'
 
 new Picker({ i18n })

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "yarn workspace @emoji-mart/website dev",
     "build": "yarn workspace @slidoapp/emoji-mart build",
-    "build:data": "yarn workspace @emoji-mart/data build",
+    "build:data": "yarn workspace @slidoapp/emoji-mart-data build",
     "build:react": "yarn workspace @slidoapp/emoji-mart-react build",
     "build:website": "yarn workspace @emoji-mart/website build",
     "check:types": "tsc",

--- a/packages/emoji-mart-data/README.md
+++ b/packages/emoji-mart-data/README.md
@@ -1,3 +1,3 @@
-# `@emoji-mart/data`
+# `@slidoapp/emoji-mart-data`
 
 This package contains the data used by [EmojiMart](https://missiveapp.com/open/emoji-mart).

--- a/packages/emoji-mart-data/package.json
+++ b/packages/emoji-mart-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slidoapp/emoji-mart-data",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Data for Emoji Mart; the emoji picker for the web.",
   "license": "MIT",
   "homepage": "https://missiveapp.com/open/emoji-mart",

--- a/packages/emoji-mart-data/package.json
+++ b/packages/emoji-mart-data/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@emoji-mart/data",
+  "name": "@slidoapp/emoji-mart-data",
   "version": "1.2.1",
   "description": "Data for Emoji Mart; the emoji picker for the web.",
   "license": "MIT",
   "homepage": "https://missiveapp.com/open/emoji-mart",
   "repository": {
     "type": "git",
-    "url": "https://github.com/missive/emoji-mart",
+    "url": "https://github.com/slidoapp/emoji-mart",
     "directory": "packages/emoji-mart-data"
   },
   "main": "sets/15/native.json",

--- a/packages/emoji-mart-react/README.md
+++ b/packages/emoji-mart-react/README.md
@@ -5,11 +5,11 @@ This is a fork of Emoji Mart, done by [slidoapp](https://github.com/slidoapp/emo
 
 ## 🧑‍💻 Usage
 ```sh
-npm install --save @slidoapp/emoji-mart @emoji-mart/data @slidoapp/emoji-mart-react
+npm install --save @slidoapp/emoji-mart @slidoapp/emoji-mart-data @slidoapp/emoji-mart-react
 ```
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import Picker from '@slidoapp/emoji-mart-react'
 
 function App() {

--- a/packages/emoji-mart-website/example-categories.html
+++ b/packages/emoji-mart-website/example-categories.html
@@ -7,7 +7,7 @@
       <img id="img-indeed" src="./assets/indeed.png" />
     </div>
     <script type="module">
-      import data from '@emoji-mart/data'
+      import data from '@slidoapp/emoji-mart-data'
       import { Picker } from '@slidoapp/emoji-mart'
 
       new Picker({

--- a/packages/emoji-mart-website/example-custom-font.html
+++ b/packages/emoji-mart-website/example-custom-font.html
@@ -13,7 +13,7 @@
 
   <block name="script">
     <script type="module">
-      import data from '@emoji-mart/data/sets/13.1/native.json'
+      import data from '@slidoapp/emoji-mart-data/sets/13.1/native.json'
       import { Picker } from '@slidoapp/emoji-mart'
 
       new Picker({

--- a/packages/emoji-mart-website/example-custom-styles.html
+++ b/packages/emoji-mart-website/example-custom-styles.html
@@ -27,7 +27,7 @@
 
   <block name="script">
     <script type="module">
-      import data from '@emoji-mart/data'
+      import data from '@slidoapp/emoji-mart-data'
       import { Picker } from '@slidoapp/emoji-mart'
 
       new Picker({

--- a/packages/emoji-mart-website/example-dynamic-width.html
+++ b/packages/emoji-mart-website/example-dynamic-width.html
@@ -12,7 +12,7 @@
       }
     </style>
     <script type="module">
-      import data from '@emoji-mart/data'
+      import data from '@slidoapp/emoji-mart-data'
       import { Picker } from '@slidoapp/emoji-mart'
 
       new Picker({

--- a/packages/emoji-mart-website/example-emoji-component.html
+++ b/packages/emoji-mart-website/example-emoji-component.html
@@ -32,7 +32,7 @@
       <img id="img-parrot" src="./assets/parrot.gif" />
     </div>
     <script type="module">
-      import data from '@emoji-mart/data/sets/15/twitter.json'
+      import data from '@slidoapp/emoji-mart-data/sets/15/twitter.json'
       import { init } from '@slidoapp/emoji-mart'
 
       init({

--- a/packages/emoji-mart-website/example-headless-search.html
+++ b/packages/emoji-mart-website/example-headless-search.html
@@ -11,7 +11,7 @@
 
   <block name="script">
     <script type="module">
-      import data from '@emoji-mart/data'
+      import data from '@slidoapp/emoji-mart-data'
       import { init, SearchIndex } from '@slidoapp/emoji-mart'
 
       init({ data })

--- a/packages/emoji-mart-website/example-slack-colors.html
+++ b/packages/emoji-mart-website/example-slack-colors.html
@@ -4,7 +4,7 @@
 >
   <block name="script">
     <script type="module">
-      import data from '@emoji-mart/data'
+      import data from '@slidoapp/emoji-mart-data'
       import { Picker } from '@slidoapp/emoji-mart'
 
       new Picker({

--- a/packages/emoji-mart-website/examples.html
+++ b/packages/emoji-mart-website/examples.html
@@ -12,7 +12,7 @@
   </block>
   <block name="script">
     <script type="module">
-      import data from '@emoji-mart/data'
+      import data from '@slidoapp/emoji-mart-data'
       import { init } from '@slidoapp/emoji-mart'
 
       init({ data })

--- a/packages/emoji-mart-website/index.html
+++ b/packages/emoji-mart-website/index.html
@@ -182,7 +182,7 @@
       <img id="img-parrot" src="./assets/parrot.gif" />
     </div>
     <script type="module">
-      import data from '@emoji-mart/data'
+      import data from '@slidoapp/emoji-mart-data'
       import * as EmojiMart from '@slidoapp/emoji-mart'
       window.EmojiMart = EmojiMart
 

--- a/packages/emoji-mart/README.md
+++ b/packages/emoji-mart/README.md
@@ -27,11 +27,11 @@ Data required for the picker to work has been completely decoupled from the libr
 - **Cons:** Slower initial page load (bigger file to load)
 
 ```sh
-yarn add @emoji-mart/data
+yarn add @slidoapp/emoji-mart-data
 ```
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import { Picker } from '@slidoapp/emoji-mart'
 
 new Picker({ data })
@@ -46,7 +46,7 @@ import { Picker } from '@slidoapp/emoji-mart'
 new Picker({
   data: async () => {
     const response = await fetch(
-      'https://cdn.jsdelivr.net/npm/@emoji-mart/data',
+      'https://cdn.jsdelivr.net/npm/@slidoapp/emoji-mart-data',
     )
 
     return response.json()
@@ -59,11 +59,11 @@ In this example data is fetched from a content delivery network, but it could al
 ## 🏪 Picker
 ### React
 ```sh
-npm install --save @slidoapp/emoji-mart @emoji-mart/data @slidoapp/emoji-mart-react
+npm install --save @slidoapp/emoji-mart @slidoapp/emoji-mart-data @slidoapp/emoji-mart-react
 ```
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import Picker from '@slidoapp/emoji-mart-react'
 
 function App() {
@@ -101,7 +101,7 @@ function App() {
 | **emojiButtonRadius** | `100%` | i.e. `6px`, `1em`, `100%` | The radius of the emoji buttons |
 | **emojiButtonSize** | `36` | | The size of the emoji buttons |
 | **emojiSize** | `24` | | The size of the emojis (inside the buttons) |
-| **emojiVersion** | `14` | `1`, `2`, `3`, `4`, `5`, `11`, `12`, `12.1`, `13`, `13.1`, `14` | The version of the emoji data to use. Latest version supported in `@emoji-mart/data` is currently [14](https://emojipedia.org/emoji-14.0) |
+| **emojiVersion** | `14` | `1`, `2`, `3`, `4`, `5`, `11`, `12`, `12.1`, `13`, `13.1`, `14` | The version of the emoji data to use. Latest version supported in `@slidoapp/emoji-mart-data` is currently [14](https://emojipedia.org/emoji-14.0) |
 | **exceptEmojis** | `[]` | | List of emoji IDs that will be excluded from the picker |
 | **icons** | `auto` | `auto`, `outline`, `solid` | The type of icons to use for the picker. `outline` with light theme and `solid` with dark theme. |
 | **locale** | `en` | `en`, `ar`, `be`, `cs`, `de`, `es`, `fa`, `fi`, `fr`, `hi`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `ru`, `sa`, `tr`, `uk`, `vi`, `zh` | The locale to use for the picker |
@@ -123,7 +123,7 @@ function App() {
 You can use custom emojis by providing an array of categories and their emojis. Emojis also support multiple skin tones and can be GIFs or SVGs.
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import Picker from '@slidoapp/emoji-mart-react'
 
 const custom = [
@@ -191,7 +191,7 @@ The emoji web component usage is the same no matter what library you use.
 First, you need to make sure data has been initialized. You need to call this only once per page load. Note that if you call `init` like this, you don’t necessarily need to include data in your Picker props. It doesn’t hurt either, it will noop.
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import { init } from '@slidoapp/emoji-mart'
 
 init({ data })
@@ -221,7 +221,7 @@ Then you can use the emoji component in your HTML / JSX.
 You can search without the Picker. Just like the emoji component, `data` needs to be initialized first in order to use the search index.
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import { init, SearchIndex } from '@slidoapp/emoji-mart'
 
 init({ data })
@@ -242,7 +242,7 @@ search('christmas') // => ['🎄', '🇨🇽', '🧑‍🎄', '🔔', '🤶', '�
 You can get emoji data from a native emoji. This is useful if you want to get the emoji ID from a native emoji. Just like the emoji component, `data` needs to be initialized first in order to retrieve the emoji data.
 
 ```js
-import data from '@emoji-mart/data'
+import data from '@slidoapp/emoji-mart-data'
 import { init, getEmojiDataFromNative } from '@slidoapp/emoji-mart'
 
 init({ data })
@@ -264,7 +264,7 @@ getEmojiDataFromNative('🤞🏿').then(console.log)
 EmojiMart UI supports [multiple languages](https://github.com/slidoapp/emoji-mart/tree/main/packages/emoji-mart-data/i18n), feel free to open a PR if yours is missing.
 
 ```js
-import i18n from '@emoji-mart/data/i18n/fr.json'
+import i18n from '@slidoapp/emoji-mart-data/i18n/fr.json'
 i18n.search_no_results_1 = 'Aucun emoji'
 
 new Picker({ i18n })

--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -6,7 +6,7 @@ import { FrequentlyUsed, SearchIndex, Store } from '../../helpers'
 import Icons from '../../icons'
 import { deepEqual, getEmojiData, sleep } from '../../utils'
 
-import type { Category } from '@emoji-mart/data'
+import type { Category } from '@slidoapp/emoji-mart-data'
 import { Emoji } from '../Emoji'
 import { PureInlineComponent } from '../HOCs'
 import { Navigation } from '../Navigation'

--- a/packages/emoji-mart/src/config.ts
+++ b/packages/emoji-mart/src/config.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import i18n_en from '@emoji-mart/data/i18n/en.json'
+import i18n_en from '@slidoapp/emoji-mart-data/i18n/en.json'
 import PickerProps from './components/Picker/PickerProps'
 import {
   FrequentlyUsed,
@@ -58,7 +58,7 @@ async function _init(props) {
     Data =
       (typeof props.data === 'function' ? await props.data() : props.data) ||
       (await fetchJSON(
-        `https://cdn.jsdelivr.net/npm/@emoji-mart/data@latest/sets/${emojiVersion}/${set}.json`,
+        `https://cdn.jsdelivr.net/npm/@slidoapp/emoji-mart-data@latest/sets/${emojiVersion}/${set}.json`,
       ))
 
     Data.emoticons = {}
@@ -93,7 +93,7 @@ async function _init(props) {
     (locale == 'en'
       ? i18n_en
       : await fetchJSON(
-          `https://cdn.jsdelivr.net/npm/@emoji-mart/data@latest/i18n/${locale}.json`,
+          `https://cdn.jsdelivr.net/npm/@slidoapp/emoji-mart-data@latest/i18n/${locale}.json`,
         ))
 
   if (props.custom) {


### PR DESCRIPTION
All language packages are in the @emoji-mart/data package. Since we are
adding multilingual a11y, it makes sense to take the ownership of that
package.