### PR TITLE
fix(emoji-picker): add no result to aria region

### DIFF
--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -1069,7 +1069,14 @@ export default class Picker extends Component {
 
   renderLiveRegion() {
     const emoji = this.getEmojiByPos(this.state.pos)
-    const contents = emoji ? emoji.name : ''
+    const noSearchResults =
+      this.state.searchResults && !this.state.searchResults.length
+
+    let contents = emoji
+      ? emoji.name
+      : noSearchResults
+      ? I18n.search_no_results_2
+      : ''
 
     return (
       <div aria-live="polite" class="sr-only">

--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -1072,7 +1072,7 @@ export default class Picker extends Component {
     const noSearchResults =
       this.state.searchResults && !this.state.searchResults.length
 
-    let contents = emoji
+    const contents = emoji
       ? emoji.name
       : noSearchResults
       ? I18n.search_no_results_2

--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -1070,7 +1070,7 @@ export default class Picker extends Component {
   renderLiveRegion() {
     const emoji = this.getEmojiByPos(this.state.pos)
     const noSearchResults =
-      this.state.searchResults && !this.state.searchResults.length
+      this.state.searchResults == null || this.state.searchResults.length === 0
 
     const contents = emoji
       ? emoji.name


### PR DESCRIPTION
### Description
- adds no result message to aria live region

### Related to
BUG:  Emoji - Search - No emoji found is not announced: SPARK-522103
Expected Result: No emoji found in the search results should be announced to the screen reader users,
e.g. No Emoji Found
Actual Result: When the user types in the search, the No emoji found displayed in the search results is not announced to the screen reader users.

HTML: `<div class=emoji-mart-no-results><span aria-label=, sleuth_or_spy title=sleuth_or_spy class=emoji-mart-emoji emoji-mart-emoji-native>….</div>`
Solution: Use aria-live to announce the information about No Emoji Found in the search result