### PR TITLE
fix(a11y): multiple a11y fixes

### DIFF
--- a/packages/emoji-mart-data/i18n/en.json
+++ b/packages/emoji-mart-data/i18n/en.json
@@ -2,6 +2,10 @@
   "search": "Search",
   "search_no_results_1": "Oh no!",
   "search_no_results_2": "That emoji couldn’t be found",
+  "emojis_found_plural": "emojis found",
+  "emoji_found_singular": "emoji found",
+  "search_input_aria_label": "Search emojis",
+  "available_emojis": "Available emojis",
   "pick": "Pick an emoji…",
   "add_custom": "Add custom emoji",
   "categories": {

--- a/packages/emoji-mart-data/i18n/en.json
+++ b/packages/emoji-mart-data/i18n/en.json
@@ -2,10 +2,6 @@
   "search": "Search",
   "search_no_results_1": "Oh no!",
   "search_no_results_2": "That emoji couldn’t be found",
-  "emojis_found_plural": "emojis found",
-  "emoji_found_singular": "emoji found",
-  "search_input_aria_label": "Search emojis",
-  "available_emojis": "Available emojis",
   "pick": "Pick an emoji…",
   "add_custom": "Add custom emoji",
   "categories": {
@@ -31,6 +27,9 @@
     "6": "Dark"
   },
   "a11y": {
-    "available_emojis": "Available emojis"
+    "available_emojis": "Available emojis",
+    "emojis_found_plural": "emojis found",
+    "emoji_found_singular": "emoji found",
+    "search_input_aria_label": "Search emojis"
   }
 }

--- a/packages/emoji-mart/src/components/Navigation/Navigation.tsx
+++ b/packages/emoji-mart/src/components/Navigation/Navigation.tsx
@@ -111,6 +111,7 @@ export default class Navigation extends PureComponent {
                 type="button"
                 class="flex flex-grow flex-center"
                 role="tab"
+                disabled={this.props.disabled}
                 tabIndex={selected ? 0 : -1}
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => {

--- a/packages/emoji-mart/src/components/Picker/Picker.tsx
+++ b/packages/emoji-mart/src/components/Picker/Picker.tsx
@@ -867,7 +867,9 @@ export default class Picker extends Component {
     } else {
       let count = searchResults.flat().length
       let translation =
-        count === 1 ? I18n.emoji_found_singular : I18n.emojis_found_plural
+        count === 1
+          ? I18n?.a11y?.emoji_found_singular
+          : I18n?.a11y?.emojis_found_plural
       return [count, translation].join(' ')
     }
   }
@@ -889,7 +891,7 @@ export default class Picker extends Component {
               onClick={this.handleSearchClick}
               onInput={this.handleSearchInput}
               onKeyDown={this.handleEmojisKeyDown}
-              aria-label={I18n.search_input_aria_label}
+              aria-label={I18n?.a11y?.search_input_aria_label}
               autocomplete="off"
             />
             <span aria-hidden="true" class="icon loupe flex">
@@ -974,7 +976,7 @@ export default class Picker extends Component {
         }}
         role="listbox"
         onKeyDown={this.handleEmojisKeyDown}
-        aria-label={I18n.available_emojis}
+        aria-label={I18n?.a11y?.available_emojis}
       >
         {categories.map((category) => {
           const { root, rows } = this.refs.categories.get(category.id)

--- a/packages/emoji-mart/src/components/Picker/PickerStyles.scss
+++ b/packages/emoji-mart/src/components/Picker/PickerStyles.scss
@@ -127,12 +127,15 @@
 }
 
 .sr-only {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
   height: 1px;
+  margin: -1px;
   overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 a {
@@ -291,6 +294,11 @@ button {
     transition: color var(--duration) var(--easing);
 
     &:hover { color: var(--color-a) }
+  }
+
+  button:disabled {
+    color: var(--color-c);
+    cursor: not-allowed;
   }
 
   svg, img {

--- a/packages/emoji-mart/src/components/ScreenReaderAnnouncement/index.tsx
+++ b/packages/emoji-mart/src/components/ScreenReaderAnnouncement/index.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'preact/hooks'
+
+type Level = 'assertive' | 'polite'
+
+type AnnouncementProps = {
+  text: string
+  level: Level
+  delay: number
+  timeout: number
+}
+
+/**
+ * Component which will cause a screen reader to announce a message when required.
+ */
+const ScreenReaderAnnouncement = ({
+  delay = 1500,
+  level,
+  text,
+  timeout = 2000,
+}: AnnouncementProps) => {
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    let timer = setTimeout(() => {
+      setMessage(text)
+
+      timer = setTimeout(() => {
+        setMessage('')
+      }, timeout)
+    }, delay)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [delay, text, timeout])
+
+  return (
+    <div aria-live={level} className="sr-only" aria-atomic="true">
+      {message}
+    </div>
+  )
+}
+
+export default ScreenReaderAnnouncement


### PR DESCRIPTION
# Description
- SR & Live Region
        - add new componet to handle SR annoucements with delay, as focus imput interrupts the annoucements
        - screen reader announcement no longer announces individual emojis, but rather the count of emojis found OR no emoji found message if none are found
        - add aria-atomic for the aria-live region to ensure the SR reads the whole message

- Navigation
        - disabled top navigation buttons while search input is focused

- Search
        - changed the outer div to a form with role search to improve semantics
        - add aria-hidden on the loupe icon in the search bar
        - add aria-label to the search input

- Search Result & Default Categories
        - render no result message in the preview section, when preview section is not rendered. previously the no result was only shown in the preview, but since the picker already supports hiding it, we don't want to loose the visual cue of "no emojis found"
        - add aria-label to the outer div around the all the moji categories
        - add aria-labelledby for each group of emojis pointing to the section header, and add role = group