### PR TITLE
fix: a couple of css fixes for windows high contrast mode

### DIFF
--- a/packages/emoji-mart/src/components/Picker/PickerStyles.scss
+++ b/packages/emoji-mart/src/components/Picker/PickerStyles.scss
@@ -238,6 +238,10 @@ a {
     transition-property: background-color, box-shadow;
     transition-timing-function: var(--easing);
 
+    @media (forced-colors: active) {
+      border: 1px solid ButtonBorder;
+    }
+
     &::placeholder {
       color: inherit;
       opacity: .6;
@@ -472,6 +476,7 @@ button {
   width: 16px; height: 16px;
   border-radius: 100%;
   overflow: hidden;
+  forced-color-adjust: none;
 
   &:after {
     content: "";


### PR DESCRIPTION
This is to fix part of https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-506028

This fix will:
- make the skin tone picker colour dots keep their colours in windows high contrast mode
- put a border around the search input in windows high contrast mode