### PR TITLE
chore: repair @slidoapp/emoji-mart typings and allow React 19

### DIFF
--- a/packages/emoji-mart-react/package.json
+++ b/packages/emoji-mart-react/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "@slidoapp/emoji-mart": "^5.6",
-    "react": "^16.8 || ^17 || ^18"
+    "react": "^16.8 || ^17 || ^18 || ^19"
   },
   "files": [
     "/dist",

--- a/packages/emoji-mart/src/components/Emoji/EmojiElement.jsx
+++ b/packages/emoji-mart/src/components/Emoji/EmojiElement.jsx
@@ -1,7 +1,7 @@
 import { render } from 'preact'
 
 import { init, getProps } from '../../config'
-import { HTMLElement } from '../HTMLElement'
+import HTMLElement from '../HTMLElement/HTMLElement'
 import { Emoji } from '.'
 import EmojiProps from './EmojiProps'
 

--- a/packages/emoji-mart/src/components/Picker/index.ts
+++ b/packages/emoji-mart/src/components/Picker/index.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
+import pickerStyles from 'bundle-text:./PickerStyles.scss'
+
 export { default as Picker } from './Picker'
 export { default as PickerElement } from './PickerElement'
-export { default as PickerStyles } from 'bundle-text:./PickerStyles.scss'
+export const PickerStyles: string = pickerStyles

--- a/packages/emoji-mart/src/index.ts
+++ b/packages/emoji-mart/src/index.ts
@@ -1,4 +1,5 @@
 export { PickerElement as Picker } from './components/Picker'
+export { PickerStyles } from './components/Picker'
 export { EmojiElement as Emoji } from './components/Emoji'
 
 export { FrequentlyUsed, SafeFlags, SearchIndex, Store } from './helpers'


### PR DESCRIPTION
In this commit we:
- stop generating dist typings that import from internal `components/HTMLElement`.
- export `PickerStyles` as `string` (no `bundle-text:` default export) and re-export it from the package entry.
- and expand `@slidoapp/emoji-mart-react` peerDependencies to include React `^19`.